### PR TITLE
Changes to Grid Constructor, Added markShipCells() & default Grid

### DIFF
--- a/src/main/java/core/Grid.java
+++ b/src/main/java/core/Grid.java
@@ -3,6 +3,7 @@ package core;
 import static core.Ship.Direction.HORIZONTAL;
 import static core.Ship.Direction.VERTICAL;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class Grid {
@@ -14,7 +15,7 @@ public class Grid {
     private List<Ship> shipList;
     private List<Cell> chosenCells;
 
-    public Grid(int rows, int cols) {
+    public Grid(int rows, int cols, List<Ship> shipList) {
 
         this.rows = rows;
         this.cols = cols;
@@ -24,6 +25,21 @@ public class Grid {
         for (int row = 0; row < rows; row++) {
             for (int col = 0; col < cols; col++) {
                 grid[row][col] = new Cell();
+            }
+        }
+
+        this.shipList = shipList;
+        markShipCells();
+    }
+
+    public Grid(int rows, int cols) {
+        this(rows, cols, new ArrayList<>());
+    }
+
+    private void markShipCells() {
+        for (Ship ship : shipList) {
+            for (Coord coord : ship.getCoordList()) {
+                get(coord).setAsShip();
             }
         }
     }
@@ -42,16 +58,15 @@ public class Grid {
         return cols;
     }
 
-    public void defaultShipsFor5x5() {
+    public static List<Ship> defaultShipsFor5x5() {
         Ship ship1 = new Ship(1, 2, 3, VERTICAL, "Submarine");
         Ship ship2 = new Ship(5, 1, 5, HORIZONTAL, "Carrier");
         Ship ship3 = new Ship(1, 5, 3, VERTICAL, "Destroyer");
-        shipList = List.of(ship1, ship2, ship3);
+        return List.of(ship1, ship2, ship3);
     }
 
     public static Grid defaultGrid() {
-        Grid g = new Grid(5, 5);
-        g.defaultShipsFor5x5();
+        Grid g = new Grid(5, 5, defaultShipsFor5x5());
         return g;
     }
 

--- a/src/main/java/core/Grid.java
+++ b/src/main/java/core/Grid.java
@@ -1,5 +1,8 @@
 package core;
 
+import static core.Ship.Direction.HORIZONTAL;
+import static core.Ship.Direction.VERTICAL;
+
 import java.util.List;
 
 public class Grid {
@@ -8,7 +11,7 @@ public class Grid {
 
     private Cell[][] grid;
 
-    private List<Cell> shipList;
+    private List<Ship> shipList;
     private List<Cell> chosenCells;
 
     public Grid(int rows, int cols) {
@@ -37,6 +40,19 @@ public class Grid {
 
     public int numCols() {
         return cols;
+    }
+
+    public void defaultShipsFor5x5() {
+        Ship ship1 = new Ship(1, 2, 3, VERTICAL, "Submarine");
+        Ship ship2 = new Ship(5, 1, 5, HORIZONTAL, "Carrier");
+        Ship ship3 = new Ship(1, 5, 3, VERTICAL, "Destroyer");
+        shipList = List.of(ship1, ship2, ship3);
+    }
+
+    public static Grid defaultGrid() {
+        Grid g = new Grid(5, 5);
+        g.defaultShipsFor5x5();
+        return g;
     }
 
     public boolean isValid(Coord coordinate) {

--- a/src/main/java/core/Grid.java
+++ b/src/main/java/core/Grid.java
@@ -59,9 +59,12 @@ public class Grid {
     }
 
     public static List<Ship> defaultShipsFor5x5() {
-        Ship ship1 = new Ship(1, 2, 3, VERTICAL, "Submarine");
-        Ship ship2 = new Ship(5, 1, 5, HORIZONTAL, "Carrier");
-        Ship ship3 = new Ship(1, 5, 3, VERTICAL, "Destroyer");
+        Coord c1 = new Coord(1, 2);
+        Coord c2 = new Coord(5, 1);
+        Coord c3 = new Coord(1, 5);
+        Ship ship1 = new Ship(c1, 3, VERTICAL, "Submarine");
+        Ship ship2 = new Ship(c2, 5, HORIZONTAL, "Carrier");
+        Ship ship3 = new Ship(c3, 3, VERTICAL, "Destroyer");
         return List.of(ship1, ship2, ship3);
     }
 

--- a/src/main/java/core/Ship.java
+++ b/src/main/java/core/Ship.java
@@ -53,7 +53,7 @@ public class Ship {
         return false;
     }
 
-    public List<Coord> genCoordList() {
+    private List<Coord> genCoordList() {
         List<Coord> coordList = new ArrayList<Coord>();
         if (direction == Direction.HORIZONTAL) {
             for (int i = 0; i < this.size; i++) {

--- a/src/main/java/core/Ship.java
+++ b/src/main/java/core/Ship.java
@@ -21,7 +21,7 @@ public class Ship {
         this.size = size;
         this.direction = direction;
         this.name = name;
-        this.coordList = getCoordList();
+        this.coordList = genCoordList();
     }
 
     public int getSize() {
@@ -53,7 +53,7 @@ public class Ship {
         return false;
     }
 
-    public List<Coord> getCoordList() {
+    public List<Coord> genCoordList() {
         List<Coord> coordList = new ArrayList<Coord>();
         if (direction == Direction.HORIZONTAL) {
             for (int i = 0; i < this.size; i++) {
@@ -67,6 +67,10 @@ public class Ship {
         return coordList;
     }
 
+    public List<Coord> getCoordList() {
+        return coordList;
+    }
+
     public boolean isSunk(Grid grid) {
         for (Coord coord : coordList) {
             if (!(grid.get(coord).cellIsHit())) {
@@ -77,7 +81,7 @@ public class Ship {
     }
 
     public boolean isOverlapping(Ship other) {
-        for (Coord coord : other.getCoordList()) {
+        for (Coord coord : other.genCoordList()) {
             if (this.containsCoord(coord)) {
                 return true;
             }
@@ -86,7 +90,7 @@ public class Ship {
     }
 
     public boolean isOnGrid(Grid g) {
-        for (Coord coord : this.getCoordList()) {
+        for (Coord coord : this.genCoordList()) {
             if (coord.row < 1 || coord.row > g.numRows()) return false;
             if (coord.col < 1 || coord.col > g.numCols()) return false;
         }

--- a/src/test/java/core/GridTest.java
+++ b/src/test/java/core/GridTest.java
@@ -5,12 +5,13 @@ import static org.junit.jupiter.api.Assertions.*;
 import org.junit.jupiter.api.Test;
 
 class GridTest {
-    Grid testGrid = new Grid(3, 2);
+
+    Grid testGrid = new Grid(5, 5, Grid.defaultShipsFor5x5());
 
     @Test
     public void aNewGridHasProvidedDimensions() {
-        assertEquals(testGrid.numRows(), 3);
-        assertEquals(testGrid.numCols(), 2);
+        assertEquals(testGrid.numRows(), 5);
+        assertEquals(testGrid.numCols(), 5);
     }
 
     @Test
@@ -22,6 +23,15 @@ class GridTest {
         }
     }
 
+    @Test
+    public void aNewGridCorrectlyMarksShips() {
+        assertTrue(testGrid.get(new Coord(1, 2)).hasShip());
+        assertTrue(testGrid.get(new Coord(2, 2)).hasShip());
+        assertTrue(testGrid.get(new Coord(3, 2)).hasShip());
+        assertTrue(testGrid.get(new Coord(5, 2)).hasShip());
+        assertFalse(testGrid.get(new Coord(4, 2)).hasShip());
+        assertFalse(testGrid.get(new Coord(1, 1)).hasShip());
+    }
     @Test
     public void isTheCoordinateWithinGrid() {
         Boolean result = testGrid.isValid(new Coord(3, 2));

--- a/src/test/java/core/GridTest.java
+++ b/src/test/java/core/GridTest.java
@@ -32,6 +32,7 @@ class GridTest {
         assertFalse(testGrid.get(new Coord(4, 2)).hasShip());
         assertFalse(testGrid.get(new Coord(1, 1)).hasShip());
     }
+
     @Test
     public void isTheCoordinateWithinGrid() {
         Boolean result = testGrid.isValid(new Coord(3, 2));

--- a/src/test/java/core/ShipTest.java
+++ b/src/test/java/core/ShipTest.java
@@ -48,7 +48,8 @@ class ShipTest {
     }
 
     @Test
-    public void isSunkReturnsTrueOnlyIfAllCellsMarkedAsHit() {
+    public void isSunkReturnsTrueIfAllCellsMarkedAsHit() {
+        Grid g  = new Grid(5, 5);
         Coord c1 = new Coord(1, 2);
         Coord c2 = new Coord(2, 2);
         Coord c3 = new Coord(3, 2);

--- a/src/test/java/core/ShipTest.java
+++ b/src/test/java/core/ShipTest.java
@@ -49,7 +49,7 @@ class ShipTest {
 
     @Test
     public void isSunkReturnsTrueIfAllCellsMarkedAsHit() {
-        Grid g  = new Grid(5, 5);
+        Grid g = new Grid(5, 5);
         Coord c1 = new Coord(1, 2);
         Coord c2 = new Coord(2, 2);
         Coord c3 = new Coord(3, 2);


### PR DESCRIPTION
Added a default 5x5 Grid with Ships.
Grid constructor that takes a ship list. If only given two parameters, a row and col, it creates an empty ship list. markShipCells() is used to mark all cells at the  coordinates within the ShipList as ships in the constructor.